### PR TITLE
Wordpress Smileys

### DIFF
--- a/dev/style.less
+++ b/dev/style.less
@@ -367,6 +367,10 @@ article {
 			width: 100%;
 			height: auto;
 		}
+
+		img.wp-smiley {
+			width: inherit;
+		}
 		
 
 	}// the-content


### PR DESCRIPTION
Right now the WP Smiley's are taking 100% width. Which they shouldn't. you can check it at: http://neerajkumar.name/

I have added a inherit clause for smiley code to fix this.
